### PR TITLE
2to3

### DIFF
--- a/BinaryCookieReader.py
+++ b/BinaryCookieReader.py
@@ -10,13 +10,9 @@
 # cookies from the binary Cookies.binarycookies file.                           #
 #                                                                               #
 #*******************************************************************************#
-from __future__ import print_function
 import sys
 from struct import unpack
-try:
-    from StringIO import StringIO
-except:
-    from io import StringIO
+from io import BytesIO
 from time import strftime, gmtime
 
 if len(sys.argv)!=2:
@@ -32,9 +28,10 @@ except IOError as e:
 	print( 'File Not Found :'+ FilePath )
 	sys.exit(0)
 
-file_header=binary_file.read(4)                             #File Magic String:cook
+file_header=binary_file.read(4).decode('utf-8')                             #File Magic String:cook
 
-if str(file_header)!='cook':
+
+if (file_header)!='cook':
 	print( "Not a Cookies.binarycookie file" )
 	sys.exit(0)
 
@@ -42,7 +39,7 @@ num_pages=unpack('>i',binary_file.read(4))[0]               #Number of pages in 
 
 page_sizes=[]
 for np in range(num_pages):
-	page_sizes.append(unpack('>i',binary_file.read(4))[0])  #Each page size: 4 bytes*number of pages
+    page_sizes.append(unpack('>i',binary_file.read(4))[0])  #Each page size: 4 bytes*number of pages
 
 pages=[]
 for ps in page_sizes:
@@ -54,81 +51,80 @@ print( "# BinaryCookieReader: developed by Satishb3: http://www.securitylearn.ne
 print( "#*************************************************************************#" )
 
 for page in pages:
-	page=StringIO(page)                                     #Converts the string to a file. So that we can use read/write operations easily.
-	page.read(4)                                            #page header: 4 bytes: Always 00000100
-	num_cookies=unpack('<i',page.read(4))[0]                #Number of cookies in each page, first 4 bytes after the page header in every page.
+    page=BytesIO(page)                                     #Converts the string to a file. So that we can use read/write operations easily. We'll still have to convert bytes to Unicode for strings.
+    page.read(4)                                            #page header: 4 bytes: Always 00000100
+    num_cookies=unpack('<i',page.read(4))[0]                #Number of cookies in each page, first 4 bytes after the page header in every page.
 
-	cookie_offsets=[]
-	for nc in range(num_cookies):
-		cookie_offsets.append(unpack('<i',page.read(4))[0]) #Every page contains >= one cookie. Fetch cookie starting point from page starting byte
+    cookie_offsets=[]
+    for nc in range(num_cookies):
+        cookie_offsets.append(unpack('<i',page.read(4))[0]) #Every page contains >= one cookie. Fetch cookie starting point from page starting byte
 
-	page.read(4)                                            #end of page header: Always 00000000
+    page.read(4)                                            #end of page header: Always 00000000
 
-	cookie=''
-	for offset in cookie_offsets:
-		page.seek(offset)                                   #Move the page pointer to the cookie starting point
-		cookiesize=unpack('<i',page.read(4))[0]             #fetch cookie size
-		cookie=StringIO(page.read(cookiesize))              #read the complete cookie
+    cookie=''
+    for offset in cookie_offsets:
+        page.seek(offset)                                   #Move the page pointer to the cookie starting point
+        cookiesize=unpack('<i',page.read(4))[0]             #fetch cookie size
+        cookie=BytesIO(page.read(cookiesize))              #read the complete cookie
 
-		cookie.read(4)                                      #unknown
+        cookie.read(4)                                      #unknown
 
-		flags=unpack('<i',cookie.read(4))[0]                #Cookie flags:  1=secure, 4=httponly, 5=secure+httponly
-		cookie_flags=''
-		if flags==0:
-			cookie_flags=''
-		elif flags==1:
-			cookie_flags='Secure'
-		elif flags==4:
-			cookie_flags='HttpOnly'
-		elif flags==5:
-			cookie_flags='Secure; HttpOnly'
-		else:
-			cookie_flags='Unknown'
+        flags=unpack('<i',cookie.read(4))[0]                #Cookie flags:  1=secure, 4=httponly, 5=secure+httponly
+        cookie_flags=''
+        if flags==0:
+            cookie_flags=''
+        elif flags==1:
+            cookie_flags='Secure'
+        elif flags==4:
+            cookie_flags='HttpOnly'
+        elif flags==5:
+            cookie_flags='Secure; HttpOnly'
+        else:
+            cookie_flags='Unknown'
 
-		cookie.read(4)                                      #unknown
+        cookie.read(4)                                      #unknown
 
-		urloffset=unpack('<i',cookie.read(4))[0]            #cookie domain offset from cookie starting point
-		nameoffset=unpack('<i',cookie.read(4))[0]           #cookie name offset from cookie starting point
-		pathoffset=unpack('<i',cookie.read(4))[0]           #cookie path offset from cookie starting point
-		valueoffset=unpack('<i',cookie.read(4))[0]          #cookie value offset from cookie starting point
+        urloffset=unpack('<i',cookie.read(4))[0]            #cookie domain offset from cookie starting point
+        nameoffset=unpack('<i',cookie.read(4))[0]           #cookie name offset from cookie starting point
+        pathoffset=unpack('<i',cookie.read(4))[0]           #cookie path offset from cookie starting point
+        valueoffset=unpack('<i',cookie.read(4))[0]          #cookie value offset from cookie starting point
 
-		endofcookie=cookie.read(8)                          #end of cookie
+        endofcookie=cookie.read(8)                          #end of cookie
 
-		expiry_date_epoch= unpack('<d',cookie.read(8))[0]+978307200          #Expiry date is in Mac epoch format: Starts from 1/Jan/2001
-		expiry_date=strftime("%a, %d %b %Y ",gmtime(expiry_date_epoch))[:-1] #978307200 is unix epoch of  1/Jan/2001 //[:-1] strips the last space
+        expiry_date_epoch= unpack('<d',cookie.read(8))[0]+978307200          #Expiry date is in Mac epoch format: Starts from 1/Jan/2001
+        expiry_date=strftime("%a, %d %b %Y ",gmtime(expiry_date_epoch))[:-1] #978307200 is unix epoch of  1/Jan/2001 //[:-1] strips the last space
 
-		create_date_epoch=unpack('<d',cookie.read(8))[0]+978307200           #Cookies creation time
-		create_date=strftime("%a, %d %b %Y ",gmtime(create_date_epoch))[:-1]
-		#print( create_date )
+        create_date_epoch=unpack('<d',cookie.read(8))[0]+978307200           #Cookies creation time
+        create_date=strftime("%a, %d %b %Y ",gmtime(create_date_epoch))[:-1]
 
-		cookie.seek(urloffset-4)                            #fetch domaain value from url offset
-		url=''
-		u=cookie.read(1)
-		while unpack('<b',u)[0]!=0:
-			url=url+str(u)
-			u=cookie.read(1)
+        cookie.seek(urloffset-4)                            #fetch domain value from url offset
+        url=''
+        u=cookie.read(1)
+        while unpack('<b',u)[0]!=0:
+            url=url+str(u.decode())
+            u=cookie.read(1)
 
-		cookie.seek(nameoffset-4)                           #fetch cookie name from name offset
-		name=''
-		n=cookie.read(1)
-		while unpack('<b',n)[0]!=0:
-			name=name+str(n)
-			n=cookie.read(1)
+        cookie.seek(nameoffset-4)                           #fetch cookie name from name offset
+        name=''
+        n=cookie.read(1)
+        while unpack('<b',n)[0]!=0:
+            name=name+str(n.decode())
+            n=cookie.read(1)
 
-		cookie.seek(pathoffset-4)                          #fetch cookie path from path offset
-		path=''
-		pa=cookie.read(1)
-		while unpack('<b',pa)[0]!=0:
-			path=path+str(pa)
-			pa=cookie.read(1)
+        cookie.seek(pathoffset-4)                          #fetch cookie path from path offset
+        path=''
+        pa=cookie.read(1)
+        while unpack('<b',pa)[0]!=0:
+            path=path+str(pa.decode())
+            pa=cookie.read(1)
 
-		cookie.seek(valueoffset-4)                         #fetch cookie value from value offset
-		value=''
-		va=cookie.read(1)
-		while unpack('<b',va)[0]!=0:
-			value=value+str(va)
-			va=cookie.read(1)
+        cookie.seek(valueoffset-4)                         #fetch cookie value from value offset
+        value=''
+        va=cookie.read(1)
+        while unpack('<b',va)[0]!=0:
+            value=value+str(va.decode())
+            va=cookie.read(1)
 
-		print( 'Cookie : '+name+'='+value+'; domain='+url+'; path='+path+'; '+'expires='+expiry_date+'; '+cookie_flags )
+        print( 'Cookie : '+name+'='+value+'; domain='+url+'; path='+path+'; '+'expires='+expiry_date+'; '+cookie_flags )
 
 binary_file.close()

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # josm_strava_cookies
-Utility for setting Strava cookies in JOSM preferences. This allows to get a high resolution [Strava Heatmap](https://www.strava.com/heatmap).
+Utility for setting Strava cookies in JOSM preferences. This allows to
+get a high-resolution [Strava Heatmap](https://www.strava.com/heatmap)
+as an overlay.
 
 ## Requirements
-Two possible set-ups:
-- Python 2 (the pre-installed version that comes with macOS works) +
-OSX and Safari
-- Python 3 + package 'browser_cookie3', browsers Firefox or Chrome on OSX
-- Extension to other Operating Systems is in progress
+This tool relies on Python 3, which will come pre-installed with
+most *x systems.  For OSX, a convenient way to install Python 3 is
+homebrew; see, e.g.,
+https://docs.python-guide.org/starting/install3/osx/
+
+For Safari users, no further packages are needed.
+For Chrome or Firefox, please install the package  'browser_cookie3'
+(pip install browser_cookie3):
+https://github.com/borisbabic/browser_cookie3
+
+Currently, this tool only support OSX.  Extension to other Operating Systems is in progress.
 
 ## Usage
 1. Browse to the [Strava Heatmap](https://www.strava.com/heatmap) and setup a Strava account.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # josm_strava_cookies
 Utility for setting Strava cookies in JOSM preferences. This allows to
-get a high-resolution [Strava Heatmap](https://www.strava.com/heatmap)
-as an overlay.
+get high-resolution [Strava Heatmaps](https://www.strava.com/heatmap)
+as an overlay in JOSM.
 
 ## Requirements
-This tool relies on Python 3, which will come pre-installed with
+This tool relies on Python 3, which comes pre-installed on
 most *x systems.  For OSX, a convenient way to install Python 3 is
 homebrew; see, e.g.,
 https://docs.python-guide.org/starting/install3/osx/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ tms[3,15]:https://heatmap-external-{switch:a,b,c}.strava.com/tiles-auth/run/blue
 ```
 5. Close JOSM.
 6. If using Safari on OSX: grant Terminal with full disk access (macOS System Preferences > Security & Privacy > Privacy > Full Disk Access > Add the Terminal application).
-7. From the command line run `$ python josm_strava_prefs_upd.py`
+7. From the command line, run `$ python3 josm_strava_prefs_upd.py`
 8. The imagery URL should be updated to:
 ```
 tms[3,15]:https://heatmap-external-{switch:a,b,c}.strava.com/tiles-auth/run/bluered/{zoom}/{x}/{y}.png?Key-Pair-Id=<YOUR_KEY_PAIR_ID_COOKIE_VALUE>&Policy=<YOUR_POLICY_COOKIE_VALUE>&Signature=<YOUR_SIGNATURE_COOKIE_VALUE>

--- a/carto_strava_omapdef.py
+++ b/carto_strava_omapdef.py
@@ -63,7 +63,7 @@ try:
 
 
 except StravaCFetchOsError as e:
-    print("Only Safari on macOS currently supported.")
+    print("Only Safari/Chrome/Firefox on macOS are currently supported.")
     print("Detected OS: " + e.message)
 except StravaCFetchCookieError as e:
     print("No Strava cookies found!")

--- a/josm_strava_prefs_upd.py
+++ b/josm_strava_prefs_upd.py
@@ -15,7 +15,7 @@ try:
     print("Done.")
 
 except StravaCFetchOsError as e:
-    print("Only Safari on macOS currently supported.")
+    print("Only Safari/Chrome/Firefox on macOS are currently supported.")
     print("Detected OS: " + e.message)
 except StravaCFetchCookieError as e:
     print("No Strava cookies found!")

--- a/stravaCookieFetcher.py
+++ b/stravaCookieFetcher.py
@@ -60,7 +60,8 @@ class StravaCookieFetcher(object):
             return
         except Exception as e:
             print( e )
-            print( "Couldn't retrieve appropriate cookies from Firefox, either!" )
+            print( "Couldn't retrieve appropriate cookies from Firefox." )
+            print( "All supported browsers have been tried unsuccessfully." )
         message = ( "Open https://www.strava.com/heatmap in any supported browser, and log in with your Strava account." )
         raise StravaCFetchCookieError(message) 
         
@@ -71,14 +72,16 @@ class MacOsStravaCookieFetcher(StravaCookieFetcher):
         # get the dir where file stravaCookieFetcher.py is saved
         pyFileDir = os.path.dirname(os.path.realpath(__file__))
         cookieReaderScript = (
-                                "python " + pyFileDir + "/BinaryCookieReader.py "
+                                "python3 " + pyFileDir + "/BinaryCookieReader.py "
                                 + os.path.expanduser('~/Library/Cookies/Cookies.binarycookies')
                              )
         process = subprocess.Popen(cookieReaderScript, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = process.communicate()
         try:
-            result = out.split('\n')
-        except TypeError as e:
+            out=out.decode('utf-8')
+            result=out.split('\n')
+        except Exception as e:
+            ## no access to Safari cookies
             result=None
         if result is None:
             message = "No usable Strava-heatmap cookies in Safari"
@@ -104,5 +107,6 @@ class MacOsStravaCookieFetcher(StravaCookieFetcher):
             return
         except StravaCFetchCookieError as e:
             print( e )
+            print( "Couldn't retrieve appropriate cookies from Safari, moving on" )
         super().fetchCookies()
 

--- a/util/gen_urls.sh
+++ b/util/gen_urls.sh
@@ -26,9 +26,9 @@ display_usage() {
 }
 
 get_cookies() {
-  KEY_PAIR_ID=$(python ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Key-Pair-Id|cut -d"=" -f2|cut -d";" -f1)
-  POLICY=$(python ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Policy|cut -d"=" -f2|cut -d";" -f1)
-  SIGNATURE=$(python ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Signature|cut -d"=" -f2|cut -d";" -f1)
+  KEY_PAIR_ID=$(python3 ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Key-Pair-Id|cut -d"=" -f2|cut -d";" -f1)
+  POLICY=$(python3 ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Policy|cut -d"=" -f2|cut -d";" -f1)
+  SIGNATURE=$(python3 ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Signature|cut -d"=" -f2|cut -d";" -f1)
 }
 
 out_url() {

--- a/util/icloud_carto_omapdef.sh
+++ b/util/icloud_carto_omapdef.sh
@@ -10,4 +10,4 @@ if [ ! -d "$OUTDIR" ]; then
   mkdir "$OUTDIR"
 fi
 
-python ../carto_strava_omapdef.py > "$OUTDIR/carto_strava.onlinemap"
+python3 ../carto_strava_omapdef.py > "$OUTDIR/carto_strava.onlinemap"

--- a/util/read_strava_cookies.sh
+++ b/util/read_strava_cookies.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 echo "Key-Pair-Id: "
-python ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Key-Pair-Id|cut -d"=" -f2|cut -d";" -f1
+python3 ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Key-Pair-Id|cut -d"=" -f2|cut -d";" -f1
 echo "Policy: "
-python ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Policy|cut -d"=" -f2|cut -d";" -f1
+python3 ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Policy|cut -d"=" -f2|cut -d";" -f1
 echo "Signature: "
-python ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Signature|cut -d"=" -f2|cut -d";" -f1
+python3 ../BinaryCookieReader.py ~/Library/Cookies/Cookies.binarycookies |grep CloudFront-Signature|cut -d"=" -f2|cut -d";" -f1


### PR DESCRIPTION
This PR extends PR #4 
It contains all commits contained in the former, plus some that fully port BinaryCookieReader.py (and calling code) to Python3.

Advantage: Python3 is a lot more future-proof than Python2.  Python2 is officially discontinued. Also, my previous version (see PR #3) has a somewhat clunky mix of Python2 and Python3.  This is unified here.

Disadvantage: Python2 ships with OSX out-of-the-box (for the time being).  To use Python3, users need to install it (which isn't hard, and it's explained in the updated README.md).  This limitation applies to OSX, only.

My port may not be the most elegant one (this whole bytes/Unicode thing isn't 100% transparent to me), but it does work on my machine, at least the JOSM part.  I've also ported the Shell scripts and the Cartographer scripts but couldn't test those (I don't use Cartographer).  These were pretty basic edits, though (mostly: python-->python3), so I don't expect much to go have gone wrong here.

Another step towards resolving issue #3 